### PR TITLE
New injection condition - cdt/dzeta + reordering

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -614,6 +614,11 @@ Hipace::SolveOneSlice (int islice, int step)
     // write laser aabs into fields MultiFab
     m_multi_laser.UpdateLaserAabs(islice, current_N_level, m_fields, m_3D_geom);
 
+    // detect particles to be injected
+    for (int lev=0; lev<current_N_level; ++lev) {
+        m_multi_plasma.DetectInjection(lev, m_fields, m_multi_laser, islice);
+    }
+
     // deposit current
     for (int lev=0; lev<current_N_level; ++lev) {
         if (m_explicit) {
@@ -715,10 +720,8 @@ Hipace::SolveOneSlice (int islice, int step)
     // plasma laser ionization
     m_multi_plasma.DoLaserIonization(islice, m_multi_laser.GetLaserGeom(), m_multi_laser);
 
-    // injection
-    for (int lev=0; lev<current_N_level; ++lev) {
-        m_multi_plasma.DoLaserInjection(lev, m_fields, m_multi_laser, m_3D_geom, islice);
-    }
+    // transfer of particles for injection
+    m_multi_plasma.DoTransfer(m_multi_laser, m_3D_geom, islice);
 
     // Push plasma particles
     for (int lev=0; lev<current_N_level; ++lev) {

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -38,7 +38,6 @@ public:
                    amrex::Vector<amrex::Geometry> slice_gm, amrex::Vector<amrex::Geometry> gm,
                    MultiBeam& beams);
 
-
     /** Loop over plasma species and depose their currents into the current 2D slice in fields
      *
      * \param[in,out] fields the general field class, modified by this function
@@ -112,15 +111,22 @@ public:
     void DoLaserIonization (const int islice, const amrex::Geometry& laser_geom,
                             const MultiLaser& laser);
 
-    /** Do the transfer of ionized plasma particles to beam particles
+    /** Detect the plasma particles to be injected
      *
      * \param[in] lev MR level
-     * \param[in] fields the general field class
+     * \param[in,out] fields the general field class, modified by this function
+     * \param[in] laser MultiLaser object containing the laser details
+     * \param[in] islice Slice index corresponding to the current simulation slice
+     */
+    void DetectInjection (const int lev, const Fields& fields, const MultiLaser& laser, const int islice);
+
+    /** Do the transfer of detected ionized plasma particles to beam particles
+     *
      * \param[in] laser MultiLaser object containing the laser details
      * \param[in] gm Geometry object for the whole domain
      * \param[in] islice Slice index corresponding to the current simulation slice
      */
-    void DoLaserInjection (const int lev, const Fields& fields, const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm, const int islice);
+    void DoTransfer (const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm, const int islice);
 
     /** \brief whether any plasma species uses a neutralizing background, e.g. no ion motion */
     bool AnySpeciesNeutralizeBackground () const;

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -152,11 +152,19 @@ MultiPlasma::DoLaserIonization (
 }
 
 void
-MultiPlasma::DoLaserInjection (
-    const int lev, const Fields& fields, const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm, const int islice)
+MultiPlasma::DetectInjection (
+    const int lev, const Fields& fields, const MultiLaser& laser, const int islice)
 {
     for (auto& plasma : m_all_plasmas) {
         plasma.InjectionCondition(lev, fields, laser, islice);
+    }
+}
+
+void
+MultiPlasma::DoTransfer (
+    const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm, const int islice)
+{
+    for (auto& plasma : m_all_plasmas) {
         plasma.PlasmaToBeam(laser, gm, islice);
     }
 }

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -239,6 +239,7 @@ public:
     bool m_can_laser_injection = false; /**< whether laser injection is enabled */
     amrex::Real m_uz_threshold = 1.;
     amrex::Real m_injection_weight_factor = 1.;
+    amrex::Real m_injection_threshold_factor = 1.;
     std::string m_product_beam_name = ""; /**< name of Injection product beam */
     BeamParticleContainer* m_product_beam_pc = nullptr; /**< Injection product beam */
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -766,11 +766,6 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
 
     for (PlasmaParticleIterator pti(*this); pti.isValid(); ++pti)
     {
-        //extract slice_arr and ez_comp for Ez gathering
-        //const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[pti];
-        //Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
-        //const int ez_comp = Comps[WhichSlice::This]["Ez"];
-
         // Extract laser array for A gathering
         Array3<const amrex::Real> const laser_arr = laser.getSlices().const_array(pti);
 
@@ -791,11 +786,6 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
                 Complex A_dzeta = 0;
                 doLaserGatherShapeN<2>(xp, yp, A, A_dx, A_dzeta, laser_arr,
                     dx_inv, dy_inv, dzeta_inv, x_pos_offset, y_pos_offset);
-
-                // Gather Ez
-                //amrex::Real Ezp = 0._rt;
-                //doGatherEz(xp, yp, Ezp, slice_arr, ez_comp,
-                //                       dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
                 // Calculation of uz
                 amrex::Real ux = ptd_plasma.rdata(PlasmaIdx::ux)[ip]*clight_inv;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -957,6 +957,7 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
 
     const amrex::Real insitu_radius_sq = m_insitu_radius * m_insitu_radius;
     const PhysConst phys_const = get_phys_const();
+    const amrex::Real clight = phys_const.c;
     const amrex::Real clight_inv = 1.0_rt/phys_const.c;
 
     // Loop over particle boxes

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -934,7 +934,7 @@ PlasmaToBeam (const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm,
                     ptd_beam.rdata(BeamIdx::uz)[pidx_beam] = (1+ux*ux+uy*uy - psi*psi + 0.5_rt*amrex::abs(A*A))/(2.*psi)*phys_const.c;
                     amrex::Real uz = ptd_beam.rdata(BeamIdx::uz)[pidx_beam] * clight_inv;
                     const amrex::Real gam = std::sqrt(1. + ux*ux + uy*uy + uz*uz + 0.5_rt*amrex::abs(A*A));
-                    ptd_beam.rdata(BeamIdx::w)[pidx_beam] = ptd_plasma.rdata(PlasmaIdx::w)[ip] * gam / (psi) * f;
+                    ptd_beam.rdata(BeamIdx::w)[pidx_beam] = ptd_plasma.rdata(PlasmaIdx::w)[ip] * clight*dt*dzeta_inv  //* gam / (psi) * f;
                     // conservation of j_x and j_y
                     ptd_beam.idata(BeamIdx::nsubcycles)[pidx_beam] = 0;
                     ptd_beam.idata(BeamIdx::mr_level)[pidx_beam] = 0;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -76,6 +76,7 @@ PlasmaParticleContainer::ReadParameters ()
     queryWithParser(pp, "can_laser_ionize", m_can_laser_ionize);
     queryWithParser(pp, "can_laser_injection", m_can_laser_injection);
     queryWithParser(pp, "injection_weight_factor", m_injection_weight_factor);
+    queryWithParser(pp, "injection_threshold_factor", m_injection_threshold_factor);
 
     m_can_ionize = m_can_field_ionize || m_can_laser_ionize;
 
@@ -760,6 +761,7 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
      const amrex::Real dx_inv = laser_geom.InvCellSize(0);
      const amrex::Real dy_inv = laser_geom.InvCellSize(1);
      const amrex::Real dzeta_inv = laser_geom.InvCellSize(2);
+     const amrex::Real f_t = m_injection_threshold_factor;
 
      // extract dt for the condition of injection
      const amrex::Real dt = Hipace::GetInstance().m_dt;
@@ -808,7 +810,7 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
                 const amrex::Real psi_inv = 1._rt / psi;
                 const amrex::Real gam_psi = gam * psi_inv;
 
-                amrex::Real condition = gam_psi - clight*dt*dzeta_inv; // condition for injection
+                amrex::Real condition = gam_psi - clight*dt*dzeta_inv*f_t; // condition for injection
 
                 if (ptd_plasma.id(ip)==2 && (condition >= 0)){
                     ptd_plasma.id(ip) = 3; // set the injected electron ID to 3
@@ -933,7 +935,7 @@ PlasmaToBeam (const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm,
                     ptd_beam.rdata(BeamIdx::uz)[pidx_beam] = (1+ux*ux+uy*uy - psi*psi + 0.5_rt*amrex::abs(A*A))/(2.*psi)*phys_const.c;
                     amrex::Real uz = ptd_beam.rdata(BeamIdx::uz)[pidx_beam] * clight_inv;
                     const amrex::Real gam = std::sqrt(1. + ux*ux + uy*uy + uz*uz + 0.5_rt*amrex::abs(A*A));
-                    ptd_beam.rdata(BeamIdx::w)[pidx_beam] = ptd_plasma.rdata(PlasmaIdx::w)[ip] * clight*dt*dzeta_inv;  //* gam / (psi) * f;
+                    ptd_beam.rdata(BeamIdx::w)[pidx_beam] = ptd_plasma.rdata(PlasmaIdx::w)[ip] * clight*dt*dzeta_inv *f;  //* gam / (psi) * f;
                     // conservation of j_x and j_y
                     ptd_beam.idata(BeamIdx::nsubcycles)[pidx_beam] = 0;
                     ptd_beam.idata(BeamIdx::mr_level)[pidx_beam] = 0;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -833,6 +833,7 @@ PlasmaToBeam (const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm,
     using namespace amrex::literals;
     using Complex = amrex::GpuComplex<amrex::Real>;
     const PhysConst phys_const = get_phys_const();
+    const amrex::Real clight = phys_const.c;
     const amrex::Real clight_inv = 1.0_rt/phys_const.c;
 
     auto laser_geom = laser.GetLaserGeom();

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -75,7 +75,6 @@ PlasmaParticleContainer::ReadParameters ()
     m_can_laser_injection = false;
     queryWithParser(pp, "can_laser_ionize", m_can_laser_ionize);
     queryWithParser(pp, "can_laser_injection", m_can_laser_injection);
-    queryWithParser(pp, "uz_threshold", m_uz_threshold);
     queryWithParser(pp, "injection_weight_factor", m_injection_weight_factor);
 
     m_can_ionize = m_can_field_ionize || m_can_laser_ionize;
@@ -752,7 +751,6 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
     const PhysConst phys_const = get_phys_const();
     const amrex::Real clight = phys_const.c;
     const amrex::Real clight_inv = 1.0_rt/clight;
-    amrex::Real uz_condition = m_uz_threshold;
 
     auto laser_geom = laser.GetLaserGeom();
      // Offset for converting positions to indexes
@@ -958,7 +956,6 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
 
     const amrex::Real insitu_radius_sq = m_insitu_radius * m_insitu_radius;
     const PhysConst phys_const = get_phys_const();
-    const amrex::Real clight = phys_const.c;
     const amrex::Real clight_inv = 1.0_rt/phys_const.c;
 
     // Loop over particle boxes

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -750,7 +750,8 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
     using namespace amrex::literals;
     using Complex = amrex::GpuComplex<amrex::Real>;
     const PhysConst phys_const = get_phys_const();
-    const amrex::Real clight_inv = 1.0_rt/phys_const.c;
+    const amrex::Real clight = phys_const.c;
+    const amrex::Real clight_inv = 1.0_rt/clight;
     amrex::Real uz_condition = m_uz_threshold;
 
     auto laser_geom = laser.GetLaserGeom();
@@ -762,12 +763,15 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
      const amrex::Real dy_inv = laser_geom.InvCellSize(1);
      const amrex::Real dzeta_inv = laser_geom.InvCellSize(2);
 
+     // extract dt for the condition of injection
+     const amrex::Real dt = Hipace::GetInstance().m_dt;
+
     for (PlasmaParticleIterator pti(*this); pti.isValid(); ++pti)
     {
         //extract slice_arr and ez_comp for Ez gathering
-        const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[pti];
-        Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
-        const int ez_comp = Comps[WhichSlice::This]["Ez"];
+        //const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[pti];
+        //Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
+        //const int ez_comp = Comps[WhichSlice::This]["Ez"];
 
         // Extract laser array for A gathering
         Array3<const amrex::Real> const laser_arr = laser.getSlices().const_array(pti);
@@ -791,20 +795,24 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
                     dx_inv, dy_inv, dzeta_inv, x_pos_offset, y_pos_offset);
 
                 // Gather Ez
-                amrex::Real Ezp = 0._rt;
-                doGatherEz(xp, yp, Ezp, slice_arr, ez_comp,
-                                       dx_inv, dy_inv, x_pos_offset, y_pos_offset);
+                //amrex::Real Ezp = 0._rt;
+                //doGatherEz(xp, yp, Ezp, slice_arr, ez_comp,
+                //                       dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
                 // Calculation of uz
                 amrex::Real ux = ptd_plasma.rdata(PlasmaIdx::ux)[ip]*clight_inv;
                 amrex::Real uy = ptd_plasma.rdata(PlasmaIdx::uy)[ip]*clight_inv;
                 amrex::Real psi = ptd_plasma.rdata(PlasmaIdx::psi)[ip];
-                amrex::Real uz = (1 + ux*ux + uy*uy - psi*psi 
+                amrex::Real uz = (1 + ux*ux + uy*uy - psi*psi
                     + 0.5_rt*amrex::abs(A*A))/(2.*psi);
 
-                amrex::Real condition = uz - uz_condition; // condition for injection
+                const amrex::Real gam = std::sqrt(1. + ux*ux + uy*uy + uz*uz + 0.5_rt*amrex::abs(A*A))
+                const amrex::Real psi_inv = 1._rt / psi;
+                const amrex::Real gam_psi = gam * psi_inv;
 
-                if (ptd_plasma.id(ip)==2 && (condition > 0) && (Ezp < 0)){
+                amrex::Real condition = gam_psi - clight*dt*dzeta_inv; // condition for injection
+
+                if (ptd_plasma.id(ip)==2 && (condition >= 0)){
                     ptd_plasma.id(ip) = 3; // set the injected electron ID to 3
                 }
         });
@@ -909,7 +917,7 @@ PlasmaToBeam (const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm,
 
                     amrex::Real xp = ptd_plasma.pos(0, ip);
                     amrex::Real yp = ptd_plasma.pos(1, ip);
-    
+
                     doLaserGatherShapeN<2>(xp, yp, A, A_dx, A_dzeta, laser_arr,
                         dx_inv, dy_inv, dzeta_inv, x_pos_offset, y_pos_offset);
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -806,7 +806,7 @@ InjectionCondition (const int lev, const Fields& fields, const MultiLaser& laser
                 amrex::Real uz = (1 + ux*ux + uy*uy - psi*psi
                     + 0.5_rt*amrex::abs(A*A))/(2.*psi);
 
-                const amrex::Real gam = std::sqrt(1. + ux*ux + uy*uy + uz*uz + 0.5_rt*amrex::abs(A*A))
+                const amrex::Real gam = std::sqrt(1. + ux*ux + uy*uy + uz*uz + 0.5_rt*amrex::abs(A*A));
                 const amrex::Real psi_inv = 1._rt / psi;
                 const amrex::Real gam_psi = gam * psi_inv;
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -934,7 +934,7 @@ PlasmaToBeam (const MultiLaser& laser, amrex::Vector<amrex::Geometry> const& gm,
                     ptd_beam.rdata(BeamIdx::uz)[pidx_beam] = (1+ux*ux+uy*uy - psi*psi + 0.5_rt*amrex::abs(A*A))/(2.*psi)*phys_const.c;
                     amrex::Real uz = ptd_beam.rdata(BeamIdx::uz)[pidx_beam] * clight_inv;
                     const amrex::Real gam = std::sqrt(1. + ux*ux + uy*uy + uz*uz + 0.5_rt*amrex::abs(A*A));
-                    ptd_beam.rdata(BeamIdx::w)[pidx_beam] = ptd_plasma.rdata(PlasmaIdx::w)[ip] * clight*dt*dzeta_inv  //* gam / (psi) * f;
+                    ptd_beam.rdata(BeamIdx::w)[pidx_beam] = ptd_plasma.rdata(PlasmaIdx::w)[ip] * clight*dt*dzeta_inv;  //* gam / (psi) * f;
                     // conservation of j_x and j_y
                     ptd_beam.idata(BeamIdx::nsubcycles)[pidx_beam] = 0;
                     ptd_beam.idata(BeamIdx::mr_level)[pidx_beam] = 0;


### PR DESCRIPTION
This PR follows the steps that you proposed @MaxThevenet which are:
- detect injected plasma particle and tagged to id=3. Criterion: $\frac{\gamma}{1+\psi} >= \frac{c\Delta t}{\Delta \zeta}$ * `m_injection_threshold_factor`
- deposit beam and plasma 
- convert plasma to beam. The weight is $w_b = \frac{c \Delta t}{\Delta \zeta}w_p$ *`m_injection_weight_factor`
- compute fields
- advance plasma to slice I-1
- advance beam to step n+1

Here the input script:
[input.txt](https://github.com/user-attachments/files/20350445/input.txt)

Here the submit script for running on LUMI:
[submit.sh.txt](https://github.com/user-attachments/files/20349233/submit.sh.txt)

